### PR TITLE
updated scratch def to comply with Summer20

### DIFF
--- a/config/project-scratch-def.json
+++ b/config/project-scratch-def.json
@@ -1,8 +1,10 @@
 {
     "orgName": "RecordTypeMapping Company",
     "edition": "Developer",
-    "orgPreferences" : {
-        "enabled": ["S1DesktopEnabled"]
+    "settings": {
+        "lightningExperienceSettings": {
+            "enableS1DesktopEnabled": true
+        }
     },
     "features": ["StateAndCountryPicklist"]
 }


### PR DESCRIPTION
Scratch org creation fails now when using the `orgPreferences` config. Replaced with `settings` as per the error message during `force:org:create` process: 

```
ERROR running force:org:create:  We've deprecated OrgPreferences. Update the scratch org definition file to replace OrgPreferences with their corresponding settings.

Replace the orgPreferences section:
{
    "orgPreferences": {
        "enabled": [
            "S1DesktopEnabled"
        ]
    }
}
With their updated settings:
{
    "settings": {
        "lightningExperienceSettings": {
            "enableS1DesktopEnabled": true
        }
    }
}
For more info on configuring settings in a scratch org definition file see: https://developer.salesforce.com/docs/atlas.en-us.sfdx_dev.meta/sfdx_dev/sfdx_dev_scratch_orgs.htm.
```